### PR TITLE
Adiciona a configuração de `bind_addr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/
 
 - Instalação inicial do Consul [[GH-2](https://github.com/mentoriaiac/iac_role_consul/pull/2)]
 - Cria arquivos de configuração e o script de bootstrap [[GH-3](https://github.com/mentoriaiac/iac_role_consul/pull/3)]
+- Configuração de `bind_addr` [[GH-9](https://github.com/mentoriaiac/iac_role_consul/pull/9)]
 
 [Não publicado]: https://github.com/mentoriaiac/iac-role-ATUALIZAR/compare/0.1.0...HEAD

--- a/templates/consul.hcl.j2
+++ b/templates/consul.hcl.j2
@@ -1,5 +1,10 @@
-data_dir = "/opt/consul"
+{% raw %}
+data_dir  = "/opt/consul"
+bind_addr = "{{ GetPrivateIP }}"
+
+retry_join = [<RETRY_JOIN>]
+
 ui_config {
   enabled = true
 }
-retry_join = [<RETRY_JOIN>]
+{% endraw %}

--- a/templates/server.hcl.j2
+++ b/templates/server.hcl.j2
@@ -1,4 +1,6 @@
 {% include "consul.hcl.j2" %}
 
+{% raw %}
 server = true
 bootstrap_expect = <BOOTSTRAP_EXPECT>
+{% endraw %}


### PR DESCRIPTION
Como as VMs utilizadas possuem mais de uma interface privada, o agente
do Consul não sabe qual utilizar, então é necessário especificar o IP
que será utilizado.

Esse commit usa o template de go-sockaddr `{{ GetPrivateIP }}` para
utilizar o primeiro IP privado disponível.

Refs. #4

Co-authored-by: Anderson Lima <msgli34@gmail.com>
Co-authored-by: Danilo F Rocha <snifbr@gmail.com>
Co-authored-by: Diogo Lopes <diogo.magela@hotmail.com>
Co-authored-by: Felipe Nobrega <lipenodias@gmail.com>
Co-authored-by: Guilherme Xavier <guilherme.lnx@gmail.com>

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

Closes #4

## Objetivo

Adicionar a configuração de `bind_addr`.

## Referências

- https://www.consul.io/docs/agent/options#bind_addr
- https://learn.hashicorp.com/tutorials/consul/deployment-guide#consul-addresses
- 
## Como testar

```console
$ molecule create
$ molecule converge
$ molecule login
$ cat /etc/consul.d/consul.hcl
```

Verificar que a configuração de `bind_addr` está presente.
