### PR TITLE
chore: freeze a versão do pacote rich

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ molecule==3.2.2
 molecule-docker==0.2.4
 pytest==6.2.1
 pytest-testinfra==6.1.0
+rich==10.16.2
 yamllint==1.25.0


### PR DESCRIPTION
A versão 11.0.0 do pacotre `rich` não é compatível com a versão do `ansible-lint` utilizada.

<!-- Por favor descreva seu pull request aqui. -->

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

N/A

## Objetivo

Consertar o job `linter` de CI

## Referências

https://github.com/ansible-community/ansible-lint/issues/1795

## Como testar

Verificar que o status do CI está passando.
